### PR TITLE
feat: change default merge behavior

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -2,6 +2,7 @@
 
 This CHANGELOG is a format conforming to [keep-a-changelog](https://github.com/olivierlacan/keep-a-changelog). 
 It is generated with git-chglog -o CHANGELOG.md
+It assumes the use of [conventional commits](https://www.conventionalcommits.org/)
 
 {{ if .Versions -}}
 <a name="unreleased"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ It is generated with git-chglog -o CHANGELOG.md
 <a name="v0.0.1"></a>
 ## v0.0.1
 ### Bug Fixes
-- set dependency between action secret and repo Hopefully this fixes the error on creation because terraform does not know to create the repo first
+- **github-createrepo:** set dependency between action secret and repo Hopefully this fixes the error on creation because terraform does not know to create the repo first
 
 ### CI
 - add autotag and changelog generation
@@ -22,6 +22,9 @@ It is generated with git-chglog -o CHANGELOG.md
 - repo creation
 - **github-createrepo:** enable auto_init feature
 - **github-createrepo:** add CI_TOKEN as default action secret
+
+### Pull Requests
+- Merge pull request [#1](https://github.com/roueslibres1/terragrunt-modules/issues/1) from roueslibres1/experiments
 
 
 [Unreleased]: https://github.com/roueslibres1/terragrunt-modules/compare/v0.0.1...HEAD

--- a/github/create-repo/repository.tf
+++ b/github/create-repo/repository.tf
@@ -2,8 +2,9 @@ resource "github_repository" "repo" {
   name        = var.name
   description = var.description
   visibility = var.visibility
-  allow_merge_commit = false
+  allow_merge_commit = true
   allow_squash_merge = false
+  allow_rebase_merge = false
   delete_branch_on_merge = true
   auto_init = var.auto_init
 }

--- a/version.yml
+++ b/version.yml
@@ -1,2 +1,2 @@
-current: 0.0.1
-next: 0.0.1
+current: 0.0.2
+next: 0.0.2


### PR DESCRIPTION
We disallow squash and rebase merges since they would clobber signed commits
(thank you Github for an odd implementation)